### PR TITLE
Fix dropdowns border & caret on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v0.9.4
+## Fixes dropdowns border and caret on mobile
+
+When navigating with tabs on desktop fixes the behaviour of the border-bottom and the caret animation:
+
+Before:
+![Before](https://user-images.githubusercontent.com/1814752/38494640-9415606e-3bee-11e8-837a-f1da22ae1951.gif)
+
+After:
+![After](https://user-images.githubusercontent.com/1814752/38494645-98684e92-3bee-11e8-813a-b90df1b45a8c.gif)
+
+Also prevents to lose the border-bottom when clicking (active, focus) on mobile.
+
 # v0.9.3
 ## Adds tracking ID, makes `Navigation` use any passed prop
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5679,14 +5679,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -5695,6 +5687,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -14161,14 +14161,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -14234,6 +14226,14 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.11.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "",
   "main": "index.js",
   "files": [

--- a/src/Navigation/Menu/Items/Item/Dropdown/Dropdown.less
+++ b/src/Navigation/Menu/Items/Item/Dropdown/Dropdown.less
@@ -9,21 +9,32 @@
 
     > li {
       //Opens dropdown
-      &.focus-within,
-      &:active,
-      &:focus,
-      &:focus-within {
-        > a {
-          border-bottom: 0;
-        }
+      &.dropdown {
+        &.focus-within,
+        &:active,
+        &:focus,
+        &:focus-within {
+          > a {
+            border-bottom: 0;
+          }
 
-        .dropdown-button {
-          color: @brand-light-blue;
-        }
+          .dropdown-button {
+            color: @brand-light-blue;
+            border-bottom-color: transparent;
+          }
 
-        .dropdown-menu {
-          display: block;
-          animation: showDropdown .2s cubic-bezier(.6, .2, .1, 1) both;
+          .dropdown-menu {
+            display: block;
+            animation: showDropdown .2s cubic-bezier(.6, .2, .1, 1) both;
+          }
+
+          .caret {
+            transform: rotate(-180deg);
+
+            @media (min-width: @grid-float-breakpoint) {
+              transform: none;
+            }
+          }
         }
       }
 
@@ -58,19 +69,19 @@
         .navbar-inverse & {
           color: @brand-white;
         }
+
+        &:hover {
+          border-bottom-color: transparent;
+          outline: 0;
+          color: @brand-light-blue;
+        }
       }
 
       &:active,
-      &:focus,
-      &:hover {
-        border-bottom: 0;
+      &:focus {
+        border-bottom-color: transparent;
         outline: 0;
         color: @brand-light-blue;
-        @media (max-width: @grid-float-breakpoint) {
-          .caret {
-            transform: rotate(-180deg);
-          }
-        }
       }
 
       .caret {

--- a/src/Navigation/Menu/Items/Item/Item.js
+++ b/src/Navigation/Menu/Items/Item/Item.js
@@ -16,7 +16,7 @@ const Item = ({ text, link, Icon, items }) => {
   const itemContent = <ItemContent text={text} Icon={Icon} hasCaret={hasItems} />;
 
   return (
-    <li>
+    <li className={`${hasItems ? 'dropdown' : ''}`}>
       {link ? (
         <a href={link}>{itemContent}</a>
       ) : (


### PR DESCRIPTION
# v0.9.4
## Fixes dropdowns border and caret on mobile

When navigating with tabs on desktop but small widths, fixes the behaviour of the border-bottom and the caret animation:

Before:
![Before](https://user-images.githubusercontent.com/1814752/38494640-9415606e-3bee-11e8-837a-f1da22ae1951.gif)

After:
![After](https://user-images.githubusercontent.com/1814752/38494645-98684e92-3bee-11e8-813a-b90df1b45a8c.gif)

Also prevents to lose the border-bottom when clicking (active, focus) on mobile and the little jump of the item on hover, due to border differences.