### PR TITLE
Add badge to missing Get a borderless account item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.11.6
+## Add badge to missing "Get a borderless account" item
+
 # v0.11.5
 ## Menu styles issues
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "",
   "main": "index.js",
   "files": [

--- a/src/items/itemObjects.js
+++ b/src/items/itemObjects.js
@@ -36,6 +36,9 @@ export const items = [
       {
         translationKey: 'get-borderless-account',
         link: '/{{localePath}}/borderless/',
+        badge: {
+          translationKey: 'new',
+        },
       },
       {
         translationKey: 'bank-details',


### PR DESCRIPTION
Add badge to missing "Get a borderless account" item

before:
<img width="729" alt="screen shot 2018-04-25 at 16 23 58" src="https://user-images.githubusercontent.com/36676/39255836-586b56a4-48a5-11e8-86bf-7435e180f5e3.png">

after:
<img width="729" alt="screen shot 2018-04-25 at 16 23 26" src="https://user-images.githubusercontent.com/36676/39255844-5c2f1e06-48a5-11e8-9bff-1af149bae20e.png">

As per discussion with Duncan and Julian