### PR TITLE
Menu style fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # v0.11.5
 ## Menu styles issues
 
-Update styles to non flexbox items due to issues in IOS 7 and below.
-Target paddings by language. This fix is too custom to current navbar items, but works for the moment. The ideal situation would be to remove a couple of items so we don´t have to hack the menu for medium size screens. Remove this fix when we don´t have so many items in the first level.
+- Update styles to non flexbox items due to issues in IOS 7 and below.
+
+- Target paddings by language. This fix is too custom to current navbar items, but works for the moment. The ideal situation would be to remove a couple of items so we don´t have to hack the menu for medium size screens. Remove this fix when we don´t have so many items in the first level.
 
 # v0.11.4
 ## Fix navigation in safari, safari mobile and firefox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v0.11.5
-## Update styles to non flexbox items
+## Menu styles issues
+
+Update styles to non flexbox items due to issues in IOS 7 and below.
+Target paddings by language. This fix is too custom to current navbar items, but works for the moment. The ideal situation would be to remove a couple of items so we don´t have to hack the menu for medium size screens. Remove this fix when we don´t have so many items in the first level.
 
 # v0.11.4
 ## Fix navigation in safari, safari mobile and firefox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.11.5
+## Update styles to non flexbox items
+
 # v0.11.4
 ## Fix navigation in safari, safari mobile and firefox
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "0.11.3",
+  "version": "0.11.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -21,7 +21,7 @@
       "requires": {
         "@babel/types": "7.0.0-beta.44",
         "jsesc": "2.5.1",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
       },
@@ -114,7 +114,7 @@
         "@babel/code-frame": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "babylon": {
@@ -140,7 +140,7 @@
         "debug": "3.1.0",
         "globals": "11.4.0",
         "invariant": "2.2.4",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "babylon": {
@@ -173,7 +173,7 @@
       "dev": true,
       "requires": {
         "esutils": "2.0.2",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "to-fast-properties": "2.0.0"
       },
       "dependencies": {
@@ -195,7 +195,7 @@
         "debug": "3.1.0",
         "is-array-buffer": "1.0.1",
         "is-stream": "1.1.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "url-template": "2.0.8"
       },
       "dependencies": {
@@ -603,7 +603,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       }
     },
     "async-each": {
@@ -702,7 +702,7 @@
         "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
         "private": "0.1.8",
@@ -742,7 +742,7 @@
         "babel-types": "6.26.0",
         "detect-indent": "4.0.0",
         "jsesc": "1.3.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
       }
@@ -797,7 +797,7 @@
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -868,7 +868,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1108,7 +1108,7 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1531,7 +1531,7 @@
         "babel-runtime": "6.26.0",
         "core-js": "2.5.5",
         "home-or-tmp": "2.0.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
       }
@@ -1554,7 +1554,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       }
     },
     "babel-traverse": {
@@ -1570,7 +1570,7 @@
         "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.4",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       }
     },
     "babel-types": {
@@ -1580,7 +1580,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "to-fast-properties": "1.0.3"
       }
     },
@@ -1770,7 +1770,7 @@
       }
     },
     "bootstrap": {
-      "version": "github:transferwise/bootstrap#460a261d4786b05d636e5ba97df4ccd196a9fd07",
+      "version": "github:transferwise/bootstrap#74af9c8c4966c2774697ac1368fd61bfb85c23b1",
       "dev": true
     },
     "brace-expansion": {
@@ -1938,6 +1938,12 @@
         "ieee754": "1.1.11",
         "isarray": "1.0.0"
       }
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "dev": true
     },
     "buffer-indexof": {
       "version": "1.1.1",
@@ -2194,7 +2200,7 @@
         "dom-serializer": "0.1.0",
         "entities": "1.1.1",
         "htmlparser2": "3.9.2",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "parse5": "3.0.3"
       },
       "dependencies": {
@@ -2939,7 +2945,7 @@
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha25.tgz",
       "integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
       "requires": {
-        "mdn-data": "1.1.1",
+        "mdn-data": "1.1.2",
         "source-map": "0.5.7"
       }
     },
@@ -3017,7 +3023,7 @@
           "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.27.tgz",
           "integrity": "sha512-BAYp9FyN4jLXjfvRpTDchBllDptqlK9I7OsagXCG9Am5C+5jc8eRZHgqb9x500W2OKS14MMlpQc/nmh/aA7TEQ==",
           "requires": {
-            "mdn-data": "1.1.1",
+            "mdn-data": "1.1.2",
             "source-map": "0.5.7"
           }
         }
@@ -3633,7 +3639,7 @@
         "is-number-object": "1.0.3",
         "is-string": "1.0.4",
         "is-subset": "0.1.1",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "object-inspect": "1.5.0",
         "object-is": "1.0.1",
         "object.assign": "4.1.0",
@@ -3650,7 +3656,7 @@
       "dev": true,
       "requires": {
         "enzyme-adapter-utils": "1.3.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "object.assign": "4.1.0",
         "object.values": "1.0.4",
         "prop-types": "15.6.1",
@@ -3664,7 +3670,7 @@
       "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "object.assign": "4.1.0",
         "prop-types": "15.6.1"
       }
@@ -3791,7 +3797,7 @@
         "js-yaml": "3.11.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
@@ -3964,7 +3970,7 @@
         "eslint-import-resolver-node": "0.3.2",
         "eslint-module-utils": "2.2.0",
         "has": "1.0.1",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4",
         "read-pkg-up": "2.0.0",
         "resolve": "1.7.1"
@@ -4885,28 +4891,24 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4916,14 +4918,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "bundled": true,
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
@@ -4932,40 +4932,34 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4974,29 +4968,25 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5005,15 +4995,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5029,8 +5017,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5044,15 +5031,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5061,8 +5046,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5071,8 +5055,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5082,21 +5065,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -5104,15 +5084,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
@@ -5120,14 +5098,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1",
@@ -5136,8 +5112,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5146,8 +5121,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -5155,15 +5129,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5174,8 +5146,7 @@
         },
         "node-pre-gyp": {
           "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz",
-          "integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5193,8 +5164,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5204,15 +5174,13 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5222,8 +5190,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5235,21 +5202,18 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -5257,22 +5221,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5282,22 +5243,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
-          "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5309,8 +5267,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -5318,8 +5275,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5334,8 +5290,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5344,49 +5299,42 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "bundled": true,
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -5396,8 +5344,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5406,8 +5353,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -5415,15 +5361,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5438,15 +5382,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5455,14 +5397,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "bundled": true,
           "dev": true
         }
       }
@@ -5785,7 +5725,7 @@
       "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       }
     },
     "growly": {
@@ -6137,7 +6077,7 @@
       "requires": {
         "html-minifier": "3.5.15",
         "loader-utils": "0.2.17",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "pretty-error": "2.1.1",
         "tapable": "1.0.0",
         "toposort": "1.0.6",
@@ -6197,9 +6137,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
-      "integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.12.tgz",
+      "integrity": "sha1-uc+/Sizybw/DSxDKFImid3HjR08=",
       "dev": true
     },
     "http-proxy": {
@@ -6221,7 +6161,7 @@
       "requires": {
         "http-proxy": "1.17.0",
         "is-glob": "4.0.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "micromatch": "3.1.10"
       },
       "dependencies": {
@@ -6435,7 +6375,7 @@
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
         "figures": "2.0.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -7592,7 +7532,7 @@
         "jest-message-util": "22.4.3",
         "jest-snapshot": "22.4.3",
         "jest-util": "22.4.3",
-        "source-map-support": "0.5.4"
+        "source-map-support": "0.5.5"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7622,11 +7562,12 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
-          "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
+          "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
           "dev": true,
           "requires": {
+            "buffer-from": "1.0.0",
             "source-map": "0.6.1"
           }
         },
@@ -8283,7 +8224,7 @@
         "babylon": "7.0.0-beta.46",
         "colors": "1.1.2",
         "flow-parser": "0.70.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "micromatch": "2.3.11",
         "neo-async": "2.5.1",
         "node-dir": "0.1.8",
@@ -8851,7 +8792,7 @@
         "is-glob": "4.0.0",
         "jest-validate": "21.2.1",
         "listr": "0.13.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
         "npm-which": "3.0.1",
@@ -9161,9 +9102,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash._arraymap": {
       "version": "3.0.0",
@@ -9568,9 +9509,9 @@
       }
     },
     "mdn-data": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.1.tgz",
-      "integrity": "sha512-2J5JENcb4yD5AzBI4ilTakiq2P9gHSsi4LOygnMu/bkchgTiA63AjsHAhDc+3U36AJHRfcz30Qv6Tb7i/Qsiew=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.2.tgz",
+      "integrity": "sha512-HUqqf4U+XdKomJXe2Chw+b1zPXFRUZ3bfUbrGLQ2TGwMOBRULuTHI9geusGqRL4WzsusnLLxYAxV4f/F/8wV+g=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -12252,16 +12193,16 @@
       }
     },
     "react-hot-loader": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.1.1.tgz",
-      "integrity": "sha512-bwDWesjqXABplFfqNOC6imbmW9y1JtT5RAo+hdIJ4OW2FsU48nrVzFiG8z9a+eB3Xd0C+KzFwD8aq31M+6SYKQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.1.2.tgz",
+      "integrity": "sha512-7EFwgpJOx4AG4pwVifgr/ZNBPAxl2z424nGJPc/APB3F8YtCA3WdYuGlcerRK2C9vYAoqiiLw745IB3wjnzrRQ==",
       "dev": true,
       "requires": {
         "fast-levenshtein": "2.0.6",
         "global": "4.3.2",
         "hoist-non-react-statics": "2.5.0",
         "prop-types": "15.6.1",
-        "react-lifecycles-compat": "2.0.2",
+        "react-lifecycles-compat": "3.0.2",
         "shallowequal": "1.0.2"
       }
     },
@@ -12272,9 +12213,9 @@
       "dev": true
     },
     "react-lifecycles-compat": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-2.0.2.tgz",
-      "integrity": "sha512-BPksUj7VMAAFhcCw79sZA0Ow/LTAEjs3Sio1AQcuwLeOP+ua0f/08Su2wyiW+JjDDH6fRqNy3h5CLXh21u1mVg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.2.tgz",
+      "integrity": "sha512-pbZOSMVVkvppW7XRn9fcHK5OgEDnYLwMva7P6TgS44/SN9uGGjfh3Z1c8tomO+y4IsHQ6Fsz2EGwmE7sMeNZgQ==",
       "dev": true
     },
     "react-reconciler": {
@@ -12874,7 +12815,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       }
     },
     "request-promise-native": {
@@ -13982,7 +13923,7 @@
         "dateformat": "3.0.3",
         "glob": "7.1.2",
         "js-yaml": "3.11.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "lodash.pluck": "3.1.2",
         "mkdirp": "0.5.1",
         "mustache": "2.3.0",
@@ -14049,7 +13990,7 @@
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
         "chalk": "2.4.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       },
@@ -15058,7 +14999,7 @@
             "babylon": "6.18.0",
             "colors": "1.1.2",
             "flow-parser": "0.70.0",
-            "lodash": "4.17.5",
+            "lodash": "4.17.10",
             "micromatch": "2.3.11",
             "node-dir": "0.1.8",
             "nomnom": "1.8.1",
@@ -15180,7 +15121,7 @@
         "jscodeshift": "0.5.0",
         "listr": "0.13.0",
         "loader-utils": "1.1.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "log-symbols": "2.2.0",
         "mkdirp": "0.5.1",
         "p-each-series": "1.0.0",
@@ -15245,7 +15186,7 @@
             "cli-width": "2.2.0",
             "external-editor": "2.2.0",
             "figures": "2.0.0",
-            "lodash": "4.17.5",
+            "lodash": "4.17.10",
             "mute-stream": "0.0.7",
             "run-async": "2.3.0",
             "rxjs": "5.5.10",
@@ -15466,7 +15407,7 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.11",
+        "http-parser-js": "0.4.12",
         "websocket-extensions": "0.1.3"
       }
     },
@@ -15725,7 +15666,7 @@
         "grouped-queue": "0.3.3",
         "inquirer": "3.3.0",
         "is-scoped": "1.0.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "log-symbols": "2.2.0",
         "mem-fs": "1.1.3",
         "text-table": "0.2.0",
@@ -15790,7 +15731,7 @@
         "find-up": "2.1.0",
         "github-username": "4.1.0",
         "istextorbinary": "2.2.1",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "make-dir": "1.2.0",
         "mem-fs-editor": "3.0.2",
         "minimist": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1770,7 +1770,7 @@
       }
     },
     "bootstrap": {
-      "version": "github:transferwise/bootstrap#74af9c8c4966c2774697ac1368fd61bfb85c23b1",
+      "version": "github:transferwise/bootstrap#4d2225b472013f9cc1934ca567201b073be33e8d",
       "dev": true
     },
     "brace-expansion": {
@@ -13628,9 +13628,9 @@
       }
     },
     "stable": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.7.tgz",
-      "integrity": "sha512-LmxBix+nUtyihSBpxXAhRakYEy49fan2suysdS1fUZcKjI+krXmH8DCZJ3yfngfrOnIFNU8O73EgNTzO2jI53w=="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -13953,7 +13953,7 @@
         "mkdirp": "0.5.1",
         "object.values": "1.0.4",
         "sax": "1.2.4",
-        "stable": "0.1.7",
+        "stable": "0.1.8",
         "unquote": "1.1.1",
         "util.promisify": "1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/transferwise/public-navigation#readme",
   "peerDependencies": {
-    "bootstrap": "transferwise/bootstrap#navbar-button-flexbox",
+    "bootstrap": "transferwise/bootstrap#v5.15.5",
     "react": "^16.2.0"
   },
   "devDependencies": {
@@ -47,7 +47,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
-    "bootstrap": "transferwise/bootstrap#navbar-button-flexbox",
+    "bootstrap": "transferwise/bootstrap#v5.15.5",
     "css-loader": "^0.28.9",
     "deploy-directory-on-branch-to-gh-pages": "^0.2.4",
     "enzyme": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "",
   "main": "index.js",
   "files": [
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/transferwise/public-navigation#readme",
   "peerDependencies": {
-    "bootstrap": "transferwise/bootstrap#v5.15.2",
+    "bootstrap": "transferwise/bootstrap#navbar-button-flexbox",
     "react": "^16.2.0"
   },
   "devDependencies": {
@@ -47,7 +47,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
-    "bootstrap": "transferwise/bootstrap#v5.15.2",
+    "bootstrap": "transferwise/bootstrap#navbar-button-flexbox",
     "css-loader": "^0.28.9",
     "deploy-directory-on-branch-to-gh-pages": "^0.2.4",
     "enzyme": "^3.3.0",

--- a/src/Navigation/Menu/Items/Item/ItemContent/ItemContent.js
+++ b/src/Navigation/Menu/Items/Item/ItemContent/ItemContent.js
@@ -5,8 +5,8 @@ import './ItemContent.less';
 
 const ItemContent = ({ text, Icon, hasCaret }) => (
   <Fragment>
-    <Icon className="tw-public-navigation-item-content__icon hidden-md hidden-lg hidden-xl m-r-2" />
-    <span className="text-ellipsis">{text}</span>
+    <Icon className="tw-public-navigation-item-content__icon hidden-md hidden-lg hidden-xl m-r-1" />
+    <span className="tw-public-navigation-item-content__text text-ellipsis">{text}</span>
     {hasCaret && <span className="caret" />}
   </Fragment>
 );

--- a/src/Navigation/Menu/Items/Item/ItemContent/ItemContent.less
+++ b/src/Navigation/Menu/Items/Item/ItemContent/ItemContent.less
@@ -3,3 +3,9 @@
 .tw-public-navigation-item-content__icon {
   vertical-align: middle;
 }
+
+.tw-public-navigation-item-content__text {
+  display: inline-block;
+  vertical-align: middle;
+  max-width: 164px;
+}

--- a/src/Navigation/Menu/Menu.less
+++ b/src/Navigation/Menu/Menu.less
@@ -33,31 +33,24 @@
     }
   }
 
-//Fix for long menus. Custom to current menu items.
+  //Fix for long menus. Custom to current menu items.
   .navbar-nav > li {
     > a,
     > button {
-      @media (min-width: @screen-md-min) and (max-width: @screen-lg-max) {
+      &:last-child {
+        padding-right: 24px;
+      }
+
+      @media (min-width: @screen-md-min) and (max-width: 880px) {
         padding-right: 10px;
         padding-left: 10px;
 
         &:last-child {
-          padding-right: 20px;
+          padding-right: 16px;
         }
 
         &.dropdown-toggle .caret {
           margin-left: 2px;
-        }
-      }
-
-      [lang="fr"] & {
-        @media (min-width: @screen-md-min) and (max-width: @screen-lg-max) {
-          padding-right: 4px;
-          padding-left: 4px;
-
-          &:last-child {
-            padding-right: 8px;
-          }
         }
       }
     }
@@ -66,7 +59,7 @@
 
 .tw-public-navigation-item-content__text {
   @media screen and (min-width: @screen-md-min) {
-    max-width: 88px;
+    max-width: 82px;
   }
 
   @media screen and (min-width: 880px) {
@@ -75,7 +68,48 @@
 }
 
 .navbar-right li > .dropdown-menu::before {
-  @media (min-width: @screen-md-min) and (max-width: @screen-lg-max) {
-    right: 8px;
+  @media (min-width: @screen-md-min) and (max-width: 880px) {
+    right: 14px;
+  }
+}
+
+//Long word languages
+
+[lang="es"],
+[lang="es-ES"],
+[lang="fr"],
+[lang="fr-FR"],
+[lang="de"],
+[lang="de-DE"],
+[lang="hu"],
+[lang="hu-HU"],
+[lang="ja"],
+[lang="ja-JP"],
+[lang="pl"],
+[lang="pl-PL"],
+[lang="pt"],
+[lang="pt-PT"],
+[lang="ro"],
+[lang="ro-RO"],
+[lang="ru"],
+[lang="ru-RU"] {
+  .navbar-nav > li {
+    > a,
+    > button {
+      @media (min-width: @screen-md-min) and (max-width: @screen-lg-max) {
+        padding-right: 4px;
+        padding-left: 4px;
+
+        &:last-child {
+          padding-right: 8px;
+        }
+      }
+    }
+  }
+
+  .navbar-right li > .dropdown-menu::before {
+    @media (min-width: @screen-md-min) and (max-width: @screen-lg-max) {
+      right: 8px;
+    }
   }
 }

--- a/src/Navigation/Menu/Menu.less
+++ b/src/Navigation/Menu/Menu.less
@@ -37,23 +37,40 @@
   .navbar-nav > li {
     > a,
     > button {
-      @media screen and (min-width: @screen-md-min) {
-        max-width: 114px;
-      }
-
-      @media screen and (min-width: 880px) {
-        max-width: 180px;
-      }
-
       @media (min-width: @screen-md-min) and (max-width: @screen-lg-max) {
-        padding-right: 4px;
-        padding-left: 4px;
+        padding-right: 10px;
+        padding-left: 10px;
+
+        &:last-child {
+          padding-right: 20px;
+        }
 
         &.dropdown-toggle .caret {
           margin-left: 2px;
         }
       }
+
+      [lang="fr"] & {
+        @media (min-width: @screen-md-min) and (max-width: @screen-lg-max) {
+          padding-right: 4px;
+          padding-left: 4px;
+
+          &:last-child {
+            padding-right: 8px;
+          }
+        }
+      }
     }
+  }
+}
+
+.tw-public-navigation-item-content__text {
+  @media screen and (min-width: @screen-md-min) {
+    max-width: 88px;
+  }
+
+  @media screen and (min-width: 880px) {
+    max-width: 154px;
   }
 }
 


### PR DESCRIPTION
# v0.11.5
## Menu styles issues

DEMO: https://transferwise.github.io/public-navigation/branch/menu-style-fixes/

- Update styles to non flexbox items due to issues in IOS 7 and below.
- Updated bootstrap version to v.5.15.5 (removed flexbox to items) 

*Before*

![image](https://user-images.githubusercontent.com/1814752/39263053-07be3e06-48b9-11e8-9619-a16d8513a87c.png)

*After*

![image](https://user-images.githubusercontent.com/1814752/39263088-1dbe78d8-48b9-11e8-8611-16552e61278a.png)

- Target paddings by language. It's used the `lang=""` attribute to target tha language. This fix is too custom to current navbar items, but works for the moment. The idea is that the shorter languages don´t have to suffer the small paddings used to fit the long language items.
The ideal situation would be to remove a couple of items so we don´t have to hack the menu for medium size screens. Remove this fix when we don´t have so many items in the first level.

I use both `lang="fr"` and `lang=""fr-FR` to cover also Lienzo


