### PR TITLE
Fix menu paddings to avoid collapsing in Spanish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.11.7
+## Fix menu paddings to avoid collapsing in Spanish
+![Collapsing menu in Spanish](https://user-images.githubusercontent.com/1814752/39425382-1d4e455a-4c73-11e8-8efd-782f13b26045.png)
+
+
 # v0.11.6
 ## Add badge to missing "Get a borderless account" item
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "0.11.5",
+  "version": "0.11.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "",
   "main": "index.js",
   "files": [

--- a/src/Navigation/Menu/Menu.less
+++ b/src/Navigation/Menu/Menu.less
@@ -59,7 +59,7 @@
 
 .tw-public-navigation-item-content__text {
   @media screen and (min-width: @screen-md-min) {
-    max-width: 82px;
+    max-width: 80px;
   }
 
   @media screen and (min-width: 880px) {


### PR DESCRIPTION
# v0.11.7
## Fix menu paddings to avoid collapsing in Spanish

![Collapsing menu in Spanish](https://user-images.githubusercontent.com/1814752/39425382-1d4e455a-4c73-11e8-8efd-782f13b26045.png)

Demo: 

Change the language to Spanish and html lang attribute by hand to `es` to view the fix:

![image](https://user-images.githubusercontent.com/1814752/39425762-c2d1a6ec-4c74-11e8-8217-9fc6b6ed590c.png)
