### PR TITLE
Add debit card dropdown for US locale

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,8 @@ jobs:
       - run:
           name: Deploy docs
           command: |
+            mkdir ~/.ssh
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
             git config --global user.email "circleci@transferwise.com"
             git config --global user.name "CircleCI"
             npm run deploy-docs-to-dir .
@@ -70,6 +72,8 @@ jobs:
       - run:
           name: Deploy docs
           command: |
+            mkdir ~/.ssh
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
             git config --global user.email "circleci@transferwise.com"
             git config --global user.name "CircleCI"
             npm run deploy-docs-for-branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<<<<<<< HEAD
+=======
+# v1.1.0
+## Add debit card dropdown for `US` locale
+
+>>>>>>> d270b23... Debit card dropdown for US
 # v1.0.1
 ## Remove debit card dropdown for `SG` locale
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
-<<<<<<< HEAD
-=======
 # v1.1.0
 ## Add debit card dropdown for `US` locale
 
->>>>>>> d270b23... Debit card dropdown for US
 # v1.0.1
 ## Remove debit card dropdown for `SG` locale
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "files": [

--- a/src/items/itemObjects.js
+++ b/src/items/itemObjects.js
@@ -85,6 +85,35 @@ export const items = [
     ],
   },
   {
+    isCardWaitlist: true,
+    translationKey: 'card',
+    Icon: CardIcon,
+    items: [
+      {
+        translationKey: 'join-waitlist',
+        link: '/{{localePath}}/borderless/#card',
+        badge: {
+          translationKey: 'new',
+        },
+      },
+      {
+        translationKey: 'get-borderless-account',
+        link: '/{{localePath}}/borderless/',
+        badge: {
+          translationKey: 'new',
+        },
+      },
+      {
+        translationKey: 'how-it-works',
+        link: '/{{localePath}}/borderless/#borderless-explainer-video',
+      },
+      {
+        translationKey: 'pricing',
+        link: '/{{localePath}}/borderless/pricing',
+      },
+    ],
+  },
+  {
     translationKey: 'business',
     Icon: BusinessIcon,
     items: [

--- a/src/items/l10n/rules.js
+++ b/src/items/l10n/rules.js
@@ -20,11 +20,15 @@ export const SUPPORTED_BORDERLESS_LOCALES = [
 
 export const SUPPORTED_CARD_LOCALES = ['au', 'de', 'es', 'fr', 'gb', 'hu', 'it'];
 
+export const SUPPORTED_CARD_WAITLIST_LOCALES = ['us'];
+
 export default function shouldShowItemForLocale(item, locale) {
   if (item.isBorderless) {
     return SUPPORTED_BORDERLESS_LOCALES.indexOf(locale) > -1;
   } else if (item.isCard) {
     return SUPPORTED_CARD_LOCALES.indexOf(locale) > -1;
+  } else if (item.isCardWaitlist) {
+    return SUPPORTED_CARD_WAITLIST_LOCALES.indexOf(locale) > -1;
   }
 
   return true;

--- a/src/items/l10n/rules.spec.js
+++ b/src/items/l10n/rules.spec.js
@@ -1,6 +1,7 @@
 import shouldShowItemForLocale, {
   SUPPORTED_BORDERLESS_LOCALES,
   SUPPORTED_CARD_LOCALES,
+  SUPPORTED_CARD_WAITLIST_LOCALES,
 } from './rules';
 
 fdescribe('Localization rules', () => {
@@ -28,6 +29,20 @@ fdescribe('Localization rules', () => {
   it('shows item if item is card and locale supports it', () => {
     const item = { isBorderless: true };
     const locale = SUPPORTED_CARD_LOCALES[0];
+
+    expect(shouldShowItemForLocale(item, locale)).toBe(true);
+  });
+
+  it('does not show item if item is card coming soon and locale does not support it', () => {
+    const item = { isCardWaitlist: true };
+    const locale = 'zzzzz';
+
+    expect(shouldShowItemForLocale(item, locale)).toBe(false);
+  });
+
+  it('shows item if item is card coming soon and locale supports it', () => {
+    const item = { isCardWaitlist: true };
+    const locale = SUPPORTED_CARD_WAITLIST_LOCALES[0];
 
     expect(shouldShowItemForLocale(item, locale)).toBe(true);
   });

--- a/translations/messages.json
+++ b/translations/messages.json
@@ -6,6 +6,7 @@
   "how-it-works": "How it works",
   "receive": "Receive money",
   "get-borderless-account": "Get a borderless account",
+  "join-waitlist": "Join the waitlist",
   "bank-details": "Get international bank details",
   "how-it-works": "See how it works",
   "card": "Debit card",


### PR DESCRIPTION
- Added debit card dropdown for `US` locale

Probably the `rules` file could be rearranged so every locale has better management of available links/dropdowns, current solution doesn't quite scale well (a new `if` for every condition)

before
<img width="1120" alt="screen shot 2018-07-18 at 18 49 51" src="https://user-images.githubusercontent.com/36676/42898560-62559550-8abb-11e8-9826-d6d7456e4d1e.png">


after
<img width="1120" alt="screen shot 2018-07-18 at 18 44 07" src="https://user-images.githubusercontent.com/36676/42898517-4c243ab6-8abb-11e8-8012-125c32329d5d.png">

---

changes in the circleci config fixes timeout when asking for `known_hosts`

<img width="1553" alt="screen shot 2018-07-24 at 11 33 33" src="https://user-images.githubusercontent.com/36676/43133055-7ec9d5a6-8f35-11e8-891e-6c6d909bd06d.png">
