### PR TITLE
Fix release step for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,10 @@ jobs:
             git config --global user.email "circleci@transferwise.com"
             git config --global user.name "CircleCI"
             npm run deploy-docs-to-dir .
+      - persist_to_workspace:
+          root: .
+          paths:
+            - '*'
   deploy-docs-for-branch:
     <<: *defaults
     steps:
@@ -85,6 +89,9 @@ jobs:
       - run:
           name: Setup npm token
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN_PUBLISH" >> ~/.npmrc
+      - run:
+          name: Build
+          command: npm run build
       - run:
           name: Release to GitHub
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.1.1
+## Fix release step for CI
+
 # v1.1.0
 ## Add debit card dropdown for `US` locale
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Added persist workspace in the CI workflow, missing for release step, which caused `dist` folder not to be available and returning errors below:

```Running "less:develop" (less) task
>> src/apps/landing/assets/less/landing.less: [L8:C0] '../../../../../node_modules/@transferwise/public-navigation/dist/public-navigation.css' wasn't found. Tried - node_modules/@transferwise/public-navigation/dist/public-navigation.css,node_modules/@transferwise/public-navigation/dist/public-navigation.css,../../../../../node_modules/@transferwise/public-navigation/dist/public-navigation.css
```