### PR TITLE
Fix Our story link

### DIFF
--- a/src/items/itemObjects.js
+++ b/src/items/itemObjects.js
@@ -161,7 +161,7 @@ export const items = [
       },
       {
         translationKey: 'about.our-story',
-        link: '/about/our-story',
+        link: '/fb/our-story',
       },
     ],
   },


### PR DESCRIPTION
- Fixed "Our story" link

Previously "Our story" link pointed to https://transferwise.com/about/our-story returning a 404