### PR TITLE
Support for hidden menu item

### DIFF
--- a/items/navigation.json
+++ b/items/navigation.json
@@ -17,6 +17,11 @@
         {
           "translationKey": "public-navigation.money-transfer.about",
           "link": "/:locale/about"
+        },
+        {
+          "id": "money-tracker",
+          "translationKey": "public-navigation.money-transfer.money-tracker",
+          "link": "/:locale/about/track"
         }
       ]
     },

--- a/src/PublicNavigation/PublicNavigation.js
+++ b/src/PublicNavigation/PublicNavigation.js
@@ -7,6 +7,8 @@ import Navigation from './Navigation';
 import { Locale, LocaleValues } from '../common/l10n';
 import { messages, LANGUAGES } from '../common/i18n';
 
+export const defaultDisabledItems = ['money-tracker'];
+
 const PublicNavigation = ({
   inverse,
   language,
@@ -17,6 +19,7 @@ const PublicNavigation = ({
   className,
   isUserLoggedIn,
   hasUserPreviouslyLoggedIn,
+  hiddenItemIdList,
 }) => (
   <TranslationProvider messages={messages} language={language}>
     <Navigation
@@ -24,7 +27,7 @@ const PublicNavigation = ({
       language={language}
       availableLanguages={availableLanguages}
       onLanguageChange={onLanguageChange}
-      items={getItems(locale, isUserLoggedIn, hasUserPreviouslyLoggedIn)}
+      items={getItems(locale, isUserLoggedIn, hasUserPreviouslyLoggedIn, hiddenItemIdList)}
       activePath={activePath}
       data-tracking-id="public-navigation"
       buttonItems={getButtonItems(locale, isUserLoggedIn, hasUserPreviouslyLoggedIn)}
@@ -48,6 +51,7 @@ PublicNavigation.propTypes = {
   className: Types.string,
   isUserLoggedIn: Types.bool,
   hasUserPreviouslyLoggedIn: Types.bool,
+  hiddenItemIdList: Types.arrayOf(Types.string),
 };
 
 PublicNavigation.defaultProps = {
@@ -60,6 +64,7 @@ PublicNavigation.defaultProps = {
   className: '',
   isUserLoggedIn: false,
   hasUserPreviouslyLoggedIn: false,
+  hiddenItemIdList: defaultDisabledItems,
 };
 
 export default PublicNavigation;

--- a/src/PublicNavigation/PublicNavigation.spec.js
+++ b/src/PublicNavigation/PublicNavigation.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import PublicNavigation from './PublicNavigation';
+import PublicNavigation, { defaultDisabledItems } from './PublicNavigation';
 import { getItems, getButtonItems } from './items';
 
 jest.mock('./items', () => ({ getItems: jest.fn(), getButtonItems: jest.fn() }));
@@ -18,13 +18,13 @@ describe('PublicNavigation', () => {
   it('gets items for gb locale by default', () => {
     expect(getItems).not.toBeCalled();
     publicNavigation = shallow(<PublicNavigation />);
-    expect(getItems).toBeCalledWith('gb', false, false);
+    expect(getItems).toBeCalledWith('gb', false, false, defaultDisabledItems);
   });
 
   it('gets items for passed locale', () => {
     expect(getItems).not.toBeCalled();
     publicNavigation = shallow(<PublicNavigation locale="br" />);
-    expect(getItems).toBeCalledWith('br', false, false);
+    expect(getItems).toBeCalledWith('br', false, false, defaultDisabledItems);
   });
 
   it('passes items to navigation', () => {
@@ -73,6 +73,12 @@ describe('PublicNavigation', () => {
     publicNavigation = shallow(<PublicNavigation className="heyy" />);
 
     expect(navigation().prop('className')).toEqual('heyy');
+  });
+
+  it('hidden id list passed to getItems', () => {
+    const hideIdList = ['sorry', 'Dave'];
+    publicNavigation = shallow(<PublicNavigation lang="gb" hiddenItemIdList={hideIdList} />);
+    expect(getItems).toBeCalledWith('gb', false, false, hideIdList);
   });
 
   function navigation() {

--- a/src/PublicNavigation/items/items.js
+++ b/src/PublicNavigation/items/items.js
@@ -3,11 +3,18 @@ import shouldShowItemForLocale from './l10n';
 import { interpolateLinkForLocale } from '../../common/l10n';
 import getIcon from '../../common/icons';
 
-export function getItems(locale, isUserLoggedIn = false, hasUserPreviouslyLoggedIn = false) {
+export function getItems(
+  locale,
+  isUserLoggedIn = false,
+  hasUserPreviouslyLoggedIn = false,
+  hiddenItemIdList = [],
+) {
   const items = config.items
+    .filter(item => shouldShowItem(item, hiddenItemIdList))
     .filter(item => shouldShowItemForLocale(item, locale))
     .filter(item => shouldShowItemForUser(item, isUserLoggedIn))
     .filter(item => shouldShowItemForPreviouslyLoggedUser(item, hasUserPreviouslyLoggedIn))
+    .map(item => filterHiddenSubItems(item, hiddenItemIdList))
     .map(item => localizeItem(item, locale))
     .map(addIconToItemIfExists);
   return items;
@@ -59,7 +66,6 @@ function shouldShowItemForUser(item, isUserLoggedIn) {
   ) {
     return true;
   }
-
   return false;
 }
 
@@ -68,4 +74,21 @@ function shouldShowItemForPreviouslyLoggedUser(item, hasUserPreviouslyLoggedIn) 
     return hasUserPreviouslyLoggedIn === item.showForPreviouslyLoggedInUser;
   }
   return true;
+}
+
+function shouldShowItem(item, hiddenItemIdList) {
+  if (!item.id) {
+    return true;
+  }
+  return !hiddenItemIdList.includes(item.id);
+}
+
+function filterHiddenSubItems(item, hiddenItemIdList) {
+  const filteredItem = Object.assign({}, item);
+  if (filteredItem.items) {
+    filteredItem.items = filteredItem.items.filter(subItem =>
+      shouldShowItem(subItem, hiddenItemIdList),
+    );
+  }
+  return filteredItem;
 }

--- a/src/PublicNavigation/items/items.spec.js
+++ b/src/PublicNavigation/items/items.spec.js
@@ -5,7 +5,7 @@ import getIcon from '../../common/icons';
 
 jest.mock('../../../items/navigation.json', () => ({
   items: [
-    { translationKey: 'a.key', link: '#a-link' },
+    { translationKey: 'a.key', link: '#a-link', id: 'top-id' },
     { translationKey: 'b.key', link: '#b-link', showForLoggedInUser: true },
     { translationKey: 'c.key', link: '#c-link', hideForLoggedInUser: true },
     { isCard: true, translationKey: 'card.key', link: '#card-link', icon: 'card-icon' },
@@ -16,7 +16,7 @@ jest.mock('../../../items/navigation.json', () => ({
         link: 'link',
       },
       items: [
-        { translationKey: 'a.sub-item.key', link: '#a-subitem-link' },
+        { translationKey: 'a.sub-item.key', link: '#a-subitem-link', id: 'some-id' },
         {
           translationKey: 'another.sub-item.key',
           link: '#another-subitem-link',
@@ -58,7 +58,7 @@ describe('Items', () => {
     const items = getItems('loc');
 
     expect(items).toEqual([
-      { translationKey: 'a.key', link: '#a-link' },
+      { translationKey: 'a.key', link: '#a-link', id: 'top-id' },
       { translationKey: 'c.key', link: '#c-link', hideForLoggedInUser: true },
       {
         translationKey: 'another.key',
@@ -67,7 +67,7 @@ describe('Items', () => {
           link: 'link',
         },
         items: [
-          { translationKey: 'a.sub-item.key', link: '#a-subitem-link' },
+          { translationKey: 'a.sub-item.key', link: '#a-subitem-link', id: 'some-id' },
           {
             translationKey: 'another.sub-item.key',
             link: '#another-subitem-link',
@@ -85,7 +85,7 @@ describe('Items', () => {
     const items = getItems('loc');
 
     expect(items).toEqual([
-      { translationKey: 'a.key', link: '#a-link for loc' },
+      { translationKey: 'a.key', link: '#a-link for loc', id: 'top-id' },
       { translationKey: 'c.key', link: '#c-link for loc', hideForLoggedInUser: true },
       { isCard: true, translationKey: 'card.key', link: '#card-link for loc', Icon: MockIcon },
       {
@@ -95,7 +95,7 @@ describe('Items', () => {
           link: 'link for loc',
         },
         items: [
-          { translationKey: 'a.sub-item.key', link: '#a-subitem-link for loc' },
+          { translationKey: 'a.sub-item.key', link: '#a-subitem-link for loc', id: 'some-id' },
           {
             translationKey: 'another.sub-item.key',
             link: '#another-subitem-link for loc',
@@ -113,7 +113,7 @@ describe('Items', () => {
     const items = getItems('loc');
 
     expect(items).toEqual([
-      { translationKey: 'a.key', link: '#a-link' },
+      { translationKey: 'a.key', link: '#a-link', id: 'top-id' },
       { translationKey: 'c.key', link: '#c-link', hideForLoggedInUser: true },
       {
         isCard: true,
@@ -128,7 +128,7 @@ describe('Items', () => {
           link: 'link',
         },
         items: [
-          { translationKey: 'a.sub-item.key', link: '#a-subitem-link' },
+          { translationKey: 'a.sub-item.key', link: '#a-subitem-link', id: 'some-id' },
           {
             translationKey: 'another.sub-item.key',
             link: '#another-subitem-link',
@@ -146,7 +146,7 @@ describe('Items', () => {
     const items = getItems('loc', true);
 
     expect(items).toEqual([
-      { translationKey: 'a.key', link: '#a-link' },
+      { translationKey: 'a.key', link: '#a-link', id: 'top-id' },
       { translationKey: 'b.key', link: '#b-link', showForLoggedInUser: true },
       {
         isCard: true,
@@ -161,7 +161,71 @@ describe('Items', () => {
           link: 'link',
         },
         items: [
-          { translationKey: 'a.sub-item.key', link: '#a-subitem-link' },
+          { translationKey: 'a.sub-item.key', link: '#a-subitem-link', id: 'some-id' },
+          {
+            translationKey: 'another.sub-item.key',
+            link: '#another-subitem-link',
+            badge: 'badge.key',
+          },
+        ],
+        Icon: 'Component for another-icon',
+      },
+    ]);
+  });
+
+  xit('filters subitems if id list is provided', () => {
+    getIcon.mockImplementation(name => `Component for ${name}`);
+
+    const items = getItems('loc', true, false, ['some-id']);
+
+    expect(items).toEqual([
+      { translationKey: 'a.key', link: '#a-link', id: 'top-id' },
+      { translationKey: 'b.key', link: '#b-link', showForLoggedInUser: true },
+      {
+        isCard: true,
+        translationKey: 'card.key',
+        link: '#card-link',
+        Icon: 'Component for card-icon',
+      },
+      {
+        translationKey: 'another.key',
+        link: 'some link',
+        main: {
+          link: 'link',
+        },
+        items: [
+          {
+            translationKey: 'another.sub-item.key',
+            link: '#another-subitem-link',
+            badge: 'badge.key',
+          },
+        ],
+        Icon: 'Component for another-icon',
+      },
+    ]);
+  });
+
+  it('filters top level item if id list is provided', () => {
+    getIcon.mockImplementation(name => `Component for ${name}`);
+
+    const items = getItems('loc', true, false, ['top-id']);
+
+    expect(items).toEqual([
+      { translationKey: 'b.key', link: '#b-link', showForLoggedInUser: true },
+      {
+        isCard: true,
+        translationKey: 'card.key',
+        link: '#card-link',
+        Icon: 'Component for card-icon',
+      },
+      {
+        translationKey: 'another.key',
+        link: 'some link',
+        main: {
+          link: 'link',
+        },
+        items: [
+          { translationKey: 'a.sub-item.key', link: '#a-subitem-link', id: 'some-id' },
           {
             translationKey: 'another.sub-item.key',
             link: '#another-subitem-link',

--- a/translations/messages.json
+++ b/translations/messages.json
@@ -4,6 +4,7 @@
   "public-navigation.money-transfer.send.description": "Make a one-off payment. You'll get the real exchange rate with the low fee we're known for.",
   "public-navigation.money-transfer.about": "About TransferWise",
   "public-navigation.money-transfer.send-high-amount": "Send large amounts",
+  "public-navigation.money-transfer.money-tracker": "Track your transfer",
   "public-navigation.borderless-account": "Borderless account",
   "public-navigation.borderless-account.nocard.description": "A multi-currency account for 40+ currencies. Send, receive and convert instantly with no hidden fees.",
   "public-navigation.borderless-account.card.description": "Receive money from 30+ countries. Send at the real exchange rate, and spend with a free Mastercard.",


### PR DESCRIPTION
The problem this PR solves it how to release a new menu item under a feature lock. The proposed solution is that the consuming app would control the display of certain menu items if we want to release one under feature lock. 

This could be done via setting the `hiddenItemIdList` prop to an array that matches an item's `id` in the `navigation.json` definition. To make this support clean, I introduced an optional ID property to menu items.

Feature locked menu items could be hidden by default. Setting the `defaultDisabledItems` in `PublicNavigation.js` would hide them. This is desired because PN could be used in multiple projects.