### PR TITLE
PLASTIC-3801 add sg as supportedCardLocales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.4.2
+## config change: SG is added as SUPPORTED_CARD_LOCALES
+
 # v3.4.1
 ## Support for hiding menu items via `hidden` property and revealing them with `revealHiddenItemsList` prop
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "3.3.9",
+  "version": "3.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "",
   "main": "index.js",
   "files": [

--- a/src/PublicNavigation/items/l10n/rules.js
+++ b/src/PublicNavigation/items/l10n/rules.js
@@ -1,4 +1,4 @@
-export const SUPPORTED_BORDERLESS_NO_CARD_LOCALES = ['ca', 'gr', 'sg'];
+export const SUPPORTED_BORDERLESS_NO_CARD_LOCALES = ['ca', 'gr'];
 
 export const SUPPORTED_CARD_LOCALES = [
   'au',
@@ -17,6 +17,7 @@ export const SUPPORTED_CARD_LOCALES = [
   'pl',
   'pt',
   'ro',
+  'sg',
   'us',
 ];
 


### PR DESCRIPTION
public-nav should show card icon for SG borderless.
Can be released any time from now.