### PR TITLE
Revealing language selector on tablet view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.4.3
+## Revealing language selector on tablet view
+
 # v3.4.2
 ## config change: SG is added as SUPPORTED_CARD_LOCALES
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "",
   "main": "index.js",
   "files": [

--- a/src/PublicNavigation/Navigation/Menu/Items/Item/LanguageSelector/LanguageSelector.js
+++ b/src/PublicNavigation/Navigation/Menu/Items/Item/LanguageSelector/LanguageSelector.js
@@ -21,7 +21,7 @@ const LanguageSelector = ({ language, availableLanguages, onLanguageChange }) =>
 
   return (
     <li
-      className="dropdown hidden-md tw-public-navigation-menu__language-selector"
+      className="dropdown tw-public-navigation-menu__language-selector"
       tabIndex="-1"
       ref={nodeRef}
     >


### PR DESCRIPTION
Language selector is hidden for tablet view in Homepage.
BEFORE:
<img width="576" alt="Screenshot 2019-10-21 at 14 37 10" src="https://user-images.githubusercontent.com/11547834/67202251-d2838700-f410-11e9-8167-0f661ae3dad4.png">

AFTER: 
<img width="574" alt="Screenshot 2019-10-21 at 14 37 50" src="https://user-images.githubusercontent.com/11547834/67202334-0eb6e780-f411-11e9-91cf-bf0031506c23.png">
