### PR TITLE
fix(submenu): Active link styles were being out-specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.5.1
+## Fixed a bug where active link styles were out-specified
+
 # v3.5.0
 ## Added support for submenu
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/public-navigation",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "",
   "main": "index.js",
   "files": [

--- a/src/PublicNavigation/Navigation/Menu/Items/Item/ItemContent/ItemContent.less
+++ b/src/PublicNavigation/Navigation/Menu/Items/Item/ItemContent/ItemContent.less
@@ -21,4 +21,8 @@
     }
     color: #fff;
   }
+
+  .navbar-nav > li.active > a {
+    color: @brand-light-blue;
+  }
 }


### PR DESCRIPTION
This was definitely working before but I don't know what I changed to break it.

`.nav > .active > a` assigned color to blue, but
`.navbar--inverse .navbar > li > a` assigned color to white, which won the specificity battle.

I've fixed this by assigning the active colour in the same place as the regular/hover colours.

### Broken
![image](https://user-images.githubusercontent.com/1204500/68385373-82ffc380-0151-11ea-92fb-6395f7501075.png)

### Fixed
![image](https://user-images.githubusercontent.com/1204500/68385555-f6093a00-0151-11ea-9d6f-1907356c3f72.png)
